### PR TITLE
Add basic touchOSC gyro support

### DIFF
--- a/lib/Engine_Synthy.sc
+++ b/lib/Engine_Synthy.sc
@@ -31,10 +31,12 @@ Engine_Synthy : CroneEngine {
 
 		// initialize synth defs
 		SynthDef("synthyfx",{
-			arg in, out, reverb=0.02, hold_control=5.0, t_trig=0.0, lpf=8000,flang=0;
+			arg in, out, reverb=0.02, hold_control=5.0, t_trig=0.0,
+        lpf=8000,flang=0,lpf_lag=0.2;
 			var snd,z,y,filterpos,filterswitch,flanger;
 			snd = In.ar(in,2);
 			// global filter
+      lpf = lpf.lag(lpf_lag);
 			filterswitch=EnvGen.kr(Env.new([0,1,1,0],[0.5,hold_control,4]),gate:t_trig);
 			filterpos=SelectX.kr(filterswitch,[
 				LinExp.kr(VarLag.kr(LFNoise0.kr(1/6),6,warp:\sine),-1,1,3200,8000),
@@ -306,6 +308,9 @@ Engine_Synthy : CroneEngine {
 		});
 		this.addCommand("synthy_flanger","f",{ arg msg;
 			synthySynthFX.set(\flang,msg[1]);
+		});
+		this.addCommand("synthy_gyro_juice","f",{ arg msg;
+			synthySynthFX.set(\lpf_lag,msg[1]);
 		});
 	
 

--- a/lib/Engine_Synthy.sc
+++ b/lib/Engine_Synthy.sc
@@ -32,11 +32,11 @@ Engine_Synthy : CroneEngine {
 		// initialize synth defs
 		SynthDef("synthyfx",{
 			arg in, out, reverb=0.02, hold_control=5.0, t_trig=0.0,
-        lpf=8000,flang=0,lpf_lag=0.2;
+				lpf=8000,flang=0,lpf_lag=0.2;
 			var snd,z,y,filterpos,filterswitch,flanger;
 			snd = In.ar(in,2);
 			// global filter
-      lpf = lpf.lag(lpf_lag);
+			lpf = lpf.lag(lpf_lag);
 			filterswitch=EnvGen.kr(Env.new([0,1,1,0],[0.5,hold_control,4]),gate:t_trig);
 			filterpos=SelectX.kr(filterswitch,[
 				LinExp.kr(VarLag.kr(LFNoise0.kr(1/6),6,warp:\sine),-1,1,3200,8000),

--- a/synthy.lua
+++ b/synthy.lua
@@ -100,7 +100,7 @@ function init()
     end
   end
 
-  params:add_group("SYNTHY",17)
+  params:add_group("SYNTHY",18)
   params:add_option("synthy_midi_device","midi device",midi_devices,1)
   params:add_option("synthy_midi_ch","midi channel",midi_channels,1)
   params:add_control("synthy_detuning","squishy detuning",controlspec.new(0,20,'lin',0.1,1,'',0.1/20))
@@ -167,10 +167,10 @@ function init()
   synthy.filter=0
   gyro_juice = 1.5
   osc.event=function(path,args,from)
-    local gyro_juice = params:get("synthy_gyro_juice")
     -- from touchOSC mark I (the free one):
     -- https://hexler.net/touchosc-mk1/manual/configuration-options
     if path=="/accxyz" then
+      local gyro_juice = params:get("synthy_gyro_juice")
       -- this can be VERY noisy
       --print("pos: "..pos_x..", "..pos_y..", juice:"..gyro_juice..", acc:"..args[1]..", "..args[2]..", "..args[3])
       inc_pos_x((args[1] * gyro_juice) ^ 3)

--- a/synthy.lua
+++ b/synthy.lua
@@ -171,8 +171,6 @@ function init()
     -- https://hexler.net/touchosc-mk1/manual/configuration-options
     if path=="/accxyz" then
       local gyro_juice = params:get("synthy_gyro_juice")
-      -- this can be VERY noisy
-      --print("pos: "..pos_x..", "..pos_y..", juice:"..gyro_juice..", acc:"..args[1]..", "..args[2]..", "..args[3])
       inc_pos_x((args[1] * gyro_juice) ^ 3)
       inc_lpf((args[2] * gyro_juice) ^ 3)
     end

--- a/synthy.lua
+++ b/synthy.lua
@@ -153,7 +153,7 @@ function init()
     end
   end)
   params:add_control("synthy_gyro_juice","gyro juice", 
-    controlspec.new(0.1,5,'lin',0.1,2, "tsp", 0.1))
+    controlspec.new(0.1,8,'lin',0.1,2,"tsp",0.1/8))
   params:set_action("synthy_gyro_juice", function (x) 
     engine.synthy_gyro_juice(x)
   end)


### PR DESCRIPTION
~~This has some menu issues. Scaling isn't quite right (jumps by steps > 0.1 for some reason) and it is also outside of the SYNTHY menu.~~

EDIT: menu issue fixed, ~~now just need to figure out why the param values jump.~~

EDIT: param issue fixed. a couple new issues arose though:
- [ ] For some reason the filter opens way faster than it closes with the same absolute gyro tilt, at least with my iPad. This might actually be more musical, but I'm not sure.
- [ ] When I have the menu open to tweak params, the "squishy" parameters (like wub speed and detune) are not updated. So I think there's something with the synthesis that's coupled w/ drawing, i.e. they're only called from`redraw()`
- [ ] Sometimes the animation stops updating which is a bit, uh... spooky