### PR TITLE
fix: scale note_on received velocity for MIDI range

### DIFF
--- a/synthy.lua
+++ b/synthy.lua
@@ -49,11 +49,13 @@ function note_on(note,velocity)
   end
   if params:get("synthy_midiout_device")==2 then
     -- output to ALL midi devices
+    local vel = util.round(util.linlin(0,1.0,0,127,velocity))
     for _,conn in ipairs(midi_connections) do
-      conn:note_on(note,velocity,ch)
+      conn:note_on(note,vel,ch)
     end
   elseif params:get("synthy_midiout_device")>2 then
-    midi_connections[params:get("synthy_midiout_device")-2]:note_on(note,velocity,ch)
+    local vel = util.round(util.linlin(0,1.0,0,127,velocity))
+    midi_connections[params:get("synthy_midiout_device")-2]:note_on(note,vel,ch)
   end
 
   engine.synthy_note_on(note,velocity)


### PR DESCRIPTION
report: https://llllllll.co/t/synthy/48062/49

unsure if you'll want to add any additional velocity tricks to synthy overall, but this at least scales the current velocity argument that `note_on` receives for the engine (0 to 1) to MIDI range. hope this helps! lemme know if i can contribute anything else <3